### PR TITLE
Update notebook.html

### DIFF
--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -257,10 +257,15 @@ data-notebook-path="{{notebook_path | urlencode}}"
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans %}Kernel{% endtrans %}</a>
                     <ul id="kernel_menu" class="dropdown-menu">
+			<li id="reconnect_kernel"
+                            title="{% trans %}Reconnect to the Kernel{% endtrans %}">
+                            <a href="#">{% trans %}Reconnect{% endtrans %}</a>
+                        </li>
                         <li id="int_kernel"
                             title="{% trans %}Send Keyboard Interrupt (CTRL-C) to the Kernel{% endtrans %}">
                             <a href="#">{% trans %}Interrupt{% endtrans %}</a>
                         </li>
+			<li class="divider"></li>
                         <li id="restart_kernel"
                             title="{% trans %}Restart the Kernel{% endtrans %}">
                             <a href="#">{% trans %}Restart{% endtrans %}</a>
@@ -272,10 +277,6 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         <li id="restart_run_all"
                             title="{% trans %}Restart the Kernel and re-run the notebook{% endtrans %}">
                             <a href="#">{% trans %}Restart &amp; Run All{% endtrans %}</a>
-                        </li>
-                        <li id="reconnect_kernel"
-                            title="{% trans %}Reconnect to the Kernel{% endtrans %}">
-                            <a href="#">{% trans %}Reconnect{% endtrans %}</a>
                         </li>
                         <li id="shutdown_kernel"
                             title="Shutdown the Kernel">


### PR DESCRIPTION
it is better to put interrupt at the top of the ordered list of options under kernel, and preferably order and group the options based on their impact on current kernel (it helps avoid accidentally clicking on shutdown when trying to click on reconnect.